### PR TITLE
fix: Message parsing from Json response from a Feign Client is fixed

### DIFF
--- a/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/feign/service/JsScriptEngineService.java
+++ b/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/feign/service/JsScriptEngineService.java
@@ -49,6 +49,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import clover.org.apache.commons.lang3.StringUtils;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
@@ -155,7 +156,15 @@ public class JsScriptEngineService {
                     }
                 }
                 if (feignClientExceptionAsJson.has("message")) {
-                    errorMessage = feignClientExceptionAsJson.get("message").getAsString();
+                    JsonElement messageElement = feignClientExceptionAsJson.get("message");
+                    if (messageElement.isJsonObject()) {
+                        JsonObject messageObj = messageElement.getAsJsonObject();
+                        if (messageObj.has("message") && messageObj.get("message").isJsonPrimitive()) {
+                            errorMessage = messageObj.get("message").getAsString();
+                        }
+                    } else {
+                        errorMessage = messageElement.getAsString();
+                    }
                 }
                 if (feignClientExceptionAsJson.has("details")
                         && feignClientExceptionAsJson.get("details").isJsonObject()) {

--- a/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/feign/service/JsScriptEngineService.java
+++ b/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/feign/service/JsScriptEngineService.java
@@ -166,6 +166,7 @@ public class JsScriptEngineService {
                         errorMessage = messageElement.getAsString();
                     }
                 }
+
                 if (feignClientExceptionAsJson.has("details")
                         && feignClientExceptionAsJson.get("details").isJsonObject()) {
                     String errorMessageFromJson = "";


### PR DESCRIPTION
Json response can contain 'message' property directly, or it can be enclosed into parent JsonObject. 
Initial implementation parsed only direct child 'message' property. 
This fix performs more complex parsing too.