### PR TITLE
fix: Add decryption while request template processing

### DIFF
--- a/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/service/RequestService.java
+++ b/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/service/RequestService.java
@@ -1629,7 +1629,7 @@ public class RequestService extends CrudService<Request> implements EntityHistor
                 }
                 templateResolverService.resolveTemplatesWithOrder(request, resolvingContext, evaluator);
                 requestForHistory = generateRequestForHistory(request);
-                templateResolverService.processEncryptedValues(request, false);
+                templateResolverService.processEncryptedValues(request, true);
                 templateResolverService.processEncryptedValues(requestForHistory, true);
                 consoleLogs = jsResult.getConsoleLogs();
                 RequestPreExecuteResponse requestPreExecuteResponse = preExecuteProcessing(projectId,


### PR DESCRIPTION
Old (incorrect) behavior:
- In RequestService#executeRequest method, encrypted context variables were not decrypted during request template processing.

This fix turns decryption on during request template processing.