### PR TITLE
fix: update OpenFeign properties for SpringBoot 3 Migration.

### DIFF
--- a/atp-itf-lite-backend-app/src/main/resources/application.properties
+++ b/atp-itf-lite-backend-app/src/main/resources/application.properties
@@ -33,11 +33,11 @@ atp.service.internal=${ATP_INTERNAL_GATEWAY_ENABLED:true}
 feign.atp.ram.url=${FEIGN_ATP_RAM_URL:}
 feign.atp.ram.name=${FEIGN_ATP_RAM_NAME:ATP-RAM}
 feign.atp.ram.route=${FEIGN_ATP_RAM_ROUTE:api/atp-ram/v1}
-feign.httpclient.enabled=${FEIGN_HTTPCLIENT_ENABLED:false}
-feign.okhttp.enabled=${FEIGN_OKHTTP_ENABLED:true}
+spring.cloud.openfeign.httpclient.enabled=${FEIGN_HTTPCLIENT_ENABLED:false}
+spring.cloud.openfeign.okhttp.enabled=${FEIGN_OKHTTP_ENABLED:true}
 ##========================Feign timeout================================
-feign.client.config.default.connectTimeout=${FEIGN_CONNECT_TIMEOUT:480000}
-feign.client.config.default.readTimeout=${FEIGN_READ_TIMEOUT:480000}
+spring.cloud.openfeign.client.config.default.connectTimeout=${FEIGN_CONNECT_TIMEOUT:480000}
+spring.cloud.openfeign.client.config.default.readTimeout=${FEIGN_READ_TIMEOUT:480000}
 ## catalogue
 atp.catalogue.frontend.url=${ATP_CATALOGUE_URL:}
 feign.atp.catalogue.url=${FEIGN_ATP_CATALOGUE_URL:}


### PR DESCRIPTION
Following the Spring Boot 3 (OpenFeign 4) upgrade, the legacy feign.client.config.* timeout properties were no longer applied. As a result, the itf-lite-backend service used the default Feign read timeout of 60 seconds, causing Read Timeout errors for script executions exceeding 60 seconds.
With this fix :Updated the configuration to use the Spring Boot 3 compatible property namespace spring.cloud.openfeign.client.config.*
<!-- start messages -->
### Commit messages:
[akshaymahajan855](https://github.com/Netcracker/qubership-testing-platform-itf-lite-backend/commit/3490241c5179c2c90682ee57e87f9b4d62969afe) fix: update OpenFeign properties for SpringBoot 3 Migration.
<!-- end messages -->
