### PR TITLE
fix: Fix Postman export to include request query parameters.

### DIFF
--- a/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/ei/ToPostmanRequest.java
+++ b/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/ei/ToPostmanRequest.java
@@ -58,7 +58,7 @@ public class ToPostmanRequest {
             this.body = new ToPostmanBody(request);
         }
         if (request.getUrl() != null) {
-            this.url = new ToPostmanUrl(request.getUrl());
+            this.url = new ToPostmanUrl(request.getUrl(), request.getRequestParams());
         }
         this.auth = new ToPostmanAuth(request.getAuthorization());
     }

--- a/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/ei/ToPostmanUrl.java
+++ b/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/ei/ToPostmanUrl.java
@@ -18,6 +18,8 @@ package org.qubership.atp.itf.lite.backend.model.ei;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -104,11 +106,15 @@ public class ToPostmanUrl {
 
         String activeParams = requestParams.stream()
                 .filter(param -> !param.isDisabled())
-                .map(param -> param.getValue() == null
-                        ? param.getKey() : param.getKey() + "=" + param.getValue())
+                .map(param -> encodeQueryParam(param.getKey())
+                        + (param.getValue() == null ? "" : "=" + encodeQueryParam(param.getValue())))
                 .collect(Collectors.joining("&"));
         if (StringUtils.isNotEmpty(activeParams)) {
             raw += (raw.contains("?") ? "&" : "?") + activeParams;
         }
+    }
+
+    private static String encodeQueryParam(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/ei/ToPostmanUrl.java
+++ b/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/ei/ToPostmanUrl.java
@@ -18,11 +18,13 @@ package org.qubership.atp.itf.lite.backend.model.ei;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.qubership.atp.itf.lite.backend.model.entities.http.RequestParam;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
@@ -48,6 +50,13 @@ public class ToPostmanUrl {
      * Create Postman url entity by string.
      */
     public ToPostmanUrl(String urlString) {
+        this(urlString, null);
+    }
+
+    /**
+     * Create Postman url entity by string and request parameters.
+     */
+    public ToPostmanUrl(String urlString, List<RequestParam> requestParams) {
         this.raw = urlString;
         try {
             URL url = new URL(urlString);
@@ -70,10 +79,36 @@ public class ToPostmanUrl {
                         })
                         .collect(Collectors.toList());
             }
-
         } catch (MalformedURLException e) {
             this.host = List.of(urlString);
             log.warn("Failed to parse URL '{}' during export to POSTMAN", urlString);
+        }
+        try {
+            addRequestParams(requestParams);
+        } catch (RuntimeException e) {
+            log.warn("Failed to add request parameters to URL '{}' during export to POSTMAN", urlString, e);
+        }
+    }
+
+    private void addRequestParams(List<RequestParam> requestParams) {
+        if (requestParams == null || requestParams.isEmpty()) {
+            return;
+        }
+        if (query == null) {
+            query = new ArrayList<>();
+        }
+        query.addAll(requestParams.stream()
+                .map(param -> new ToPostmanMapDescriptionAndDisabled(param.getKey(), param.getValue(),
+                        param.getDescription(), param.isDisabled()))
+                .collect(Collectors.toList()));
+
+        String activeParams = requestParams.stream()
+                .filter(param -> !param.isDisabled())
+                .map(param -> param.getValue() == null
+                        ? param.getKey() : param.getKey() + "=" + param.getValue())
+                .collect(Collectors.joining("&"));
+        if (StringUtils.isNotEmpty(activeParams)) {
+            raw += (raw.contains("?") ? "&" : "?") + activeParams;
         }
     }
 }

--- a/atp-itf-lite-backend-app/src/test/java/org/qubership/atp/itf/lite/backend/ei/ToPostmanUrlTest.java
+++ b/atp-itf-lite-backend-app/src/test/java/org/qubership/atp/itf/lite/backend/ei/ToPostmanUrlTest.java
@@ -1,0 +1,54 @@
+/*
+ * # Copyright 2026 NetCracker Technology Corporation
+ * #
+ * # Licensed under the Apache License, Version 2.0 (the "License");
+ * # you may not use this file except in compliance with the License.
+ * # You may obtain a copy of the License at
+ * #
+ * #      http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package org.qubership.atp.itf.lite.backend.ei;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.qubership.atp.itf.lite.backend.model.ei.ToPostmanMapDescriptionAndDisabled;
+import org.qubership.atp.itf.lite.backend.model.ei.ToPostmanRequest;
+import org.qubership.atp.itf.lite.backend.model.ei.ToPostmanUrl;
+import org.qubership.atp.itf.lite.backend.model.entities.http.HttpRequest;
+import org.qubership.atp.itf.lite.backend.model.entities.http.RequestParam;
+
+class ToPostmanUrlTest {
+
+    private static final String BASE_URL = "https://example.com/resource";
+
+    @Test
+    void constructor_urlWithRequestParams_exportsPostmanQuery() {
+        HttpRequest request = new HttpRequest();
+        request.setUrl(BASE_URL);
+        request.setRequestParams(List.of(
+                new RequestParam("key", "value", "description", false)));
+
+        ToPostmanUrl url = new ToPostmanRequest(request).getUrl();
+
+        assertEquals(BASE_URL + "?key=value", url.getRaw());
+        assertEquals(1, url.getQuery().size());
+        ToPostmanMapDescriptionAndDisabled queryParam =
+                assertInstanceOf(ToPostmanMapDescriptionAndDisabled.class, url.getQuery().getFirst());
+        assertEquals("key", queryParam.getKey());
+        assertEquals("value", queryParam.getValue());
+        assertEquals("description", queryParam.getDescription());
+        assertFalse(queryParam.isDisabled());
+    }
+}

--- a/atp-itf-lite-backend-app/src/test/java/org/qubership/atp/itf/lite/backend/ei/ToPostmanUrlTest.java
+++ b/atp-itf-lite-backend-app/src/test/java/org/qubership/atp/itf/lite/backend/ei/ToPostmanUrlTest.java
@@ -34,7 +34,7 @@ class ToPostmanUrlTest {
     private static final String BASE_URL = "https://example.com/resource";
 
     @Test
-    void constructor_urlWithRequestParams_exportsPostmanQuery() {
+    void exportsPostmanQuery() {
         HttpRequest request = new HttpRequest();
         request.setUrl(BASE_URL);
         request.setRequestParams(List.of(
@@ -50,5 +50,48 @@ class ToPostmanUrlTest {
         assertEquals("value", queryParam.getValue());
         assertEquals("description", queryParam.getDescription());
         assertFalse(queryParam.isDisabled());
+    }
+
+    @Test
+    void encodesUnicodeAndSpecialCharacters() {
+        String key = "ключ name&[]";
+        String value = "тест value&[]=✓";
+        HttpRequest request = new HttpRequest();
+        request.setUrl(BASE_URL);
+        request.setRequestParams(List.of(
+                new RequestParam(key, value, null, false)));
+
+        ToPostmanUrl url = new ToPostmanRequest(request).getUrl();
+        String expected = BASE_URL
+                + "?%D0%BA%D0%BB%D1%8E%D1%87%20name%26%5B%5D="
+                + "%D1%82%D0%B5%D1%81%D1%82%20value%26%5B%5D%3D%E2%9C%93";
+
+        assertEquals(expected, url.getRaw());
+        assertEquals(key, url.getQuery().getFirst().getKey());
+        assertEquals(value, url.getQuery().getFirst().getValue());
+    }
+
+    @Test
+    void encodesEmailSpecialCharacters() {
+        HttpRequest request = new HttpRequest();
+        request.setUrl(BASE_URL);
+        request.setRequestParams(List.of(
+                new RequestParam("email", "john+test@example.com", null, false)));
+
+        ToPostmanUrl url = new ToPostmanRequest(request).getUrl();
+
+        assertEquals(BASE_URL + "?email=john%2Btest%40example.com", url.getRaw());
+    }
+
+    @Test
+    void encodesKeyWithoutValue() {
+        HttpRequest request = new HttpRequest();
+        request.setUrl(BASE_URL);
+        request.setRequestParams(List.of(
+                new RequestParam("key with space", null, null, false)));
+
+        ToPostmanUrl url = new ToPostmanRequest(request).getUrl();
+
+        assertEquals(BASE_URL + "?key%20with%20space", url.getRaw());
     }
 }


### PR DESCRIPTION
For Export Funcitonality with Postman format , ITF Lite exported only the base request URL to Postman, while query parameters stored separately in requestParams were omitted. This change passes requestParams to ToPostmanUrl, populates Postman's query section, and appends enabled query parameters to the raw URL.

<!-- start messages -->
### Commit messages:
[akshaymahajan855](https://github.com/Netcracker/qubership-testing-platform-itf-lite-backend/commit/7d950e1f60c3743eea4f38bd5fb56ea6c103572b) fix: update OpenFeign properties for SpringBoot 3 Migration.
[akshaymahajan855](https://github.com/Netcracker/qubership-testing-platform-itf-lite-backend/commit/ff1882714d2af2b58d316091c32c422cb3ad62c8) fix: encode request parameters in exported Postman URL
<!-- end messages -->

