### PR TITLE
fix: Fix binary request failure in collection runs by making FileBody…

### DIFF
--- a/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/entities/FileBody.java
+++ b/atp-itf-lite-backend-app/src/main/java/org/qubership/atp/itf/lite/backend/model/entities/FileBody.java
@@ -16,10 +16,12 @@
 
 package org.qubership.atp.itf.lite.backend.model.entities;
 
+import java.io.Serializable;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import org.qubership.atp.itf.lite.backend.annotations.SerializableCheckable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -31,7 +33,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Embeddable
-public class FileBody {
+@SerializableCheckable
+public class FileBody implements Serializable {
     @Column(name = "file_name")
     private String fileName;
     @Column(name = "file_id")


### PR DESCRIPTION
Run Collection is failing for binary-body requests as FileBody is not serializable during request size validation. The same request worked with Send Request as the file was sent separately. This change makes FileBody implement Serializable and adds @SerializableCheckable .
<!-- start messages -->
### Commit messages:
[akshaymahajan855](https://github.com/Netcracker/qubership-testing-platform-itf-lite-backend/commit/0bc6887948f2aa98938cbd584abde549aec234dd) fix: Fix binary request failure in collection runs by making FileBody serializable.
<!-- end messages -->
